### PR TITLE
browseForFileURL updated

### DIFF
--- a/Export ActionScript.jsfl
+++ b/Export ActionScript.jsfl
@@ -119,7 +119,7 @@ function replaceEntities(str){
 }
 
 function init(){
-	var saveFile = fl.browseForFileURL("save", "Save File");
+	var saveFile = fl.browseForFileURL( "save", "Save File", "HTML (*.html)", "html");
 	if (saveFile) {
 		var templateFile = fl.configURI + "Commands/Export ActionScript/template.html";
 		var str = FLfile.read(templateFile);


### PR DESCRIPTION
fl.browseForFileURL( "save", "Save File" ); not working in CC, 

updated to: fl.browseForFileURL( "save", "Save File", "HTML (*.html)", "html" );